### PR TITLE
Handle audio with > 2^31 samples

### DIFF
--- a/jni/external/zenilib/zeni_audio/Sound_Buffer.cpp
+++ b/jni/external/zenilib/zeni_audio/Sound_Buffer.cpp
@@ -140,15 +140,16 @@ namespace Zeni {
 
     /*** Load the Audio File ***/
 
-    int bytes = 0;
-    int buffer_size = int(pcm_size);
-    std::vector<char> buffer( static_cast<size_t>(buffer_size) );
-    for(char *begin = &buffer[0], *end = begin + pcm_size;
+	long bytes_read = 0;
+	const size_t buffer_size = static_cast<size_t>(pcm_size);
+	size_t remaining = buffer_size;
+    std::vector<char> buffer(buffer_size);
+    for(char *begin = &buffer[0], *end = begin + buffer_size;
         begin != end;
-        begin += bytes, buffer_size -= bytes) {
-      bytes = int(ov_read(&oggFile, begin, buffer_size, 0, 2, 1, 0));
-
-      if(!bytes) {
+        begin += bytes_read, remaining -= bytes_read) {
+	  int length = remaining > 4096 ? 4096 : int(remaining);
+      bytes_read = ov_read(&oggFile, begin, length, 0, 2, 1, 0);
+      if(bytes_read < 0) {
         ov_clear(&oggFile);
         throw Sound_Buffer_Init_Failure();
       }


### PR DESCRIPTION
Vorbis file wants an int for the length to read since it never reads more than one Vorbis packet at a time. So if we read in 4096 byte chunks until the end, instead of always passing in the number of bytes casted to an int, we can load audio files that have more than 2^31 bytes uncompressed, which roughly corresponds to a 200 minute long stereo song.

2^31 bytes \* (1 sample / (2 bytes \* 2 channels) ) \* (1 sec / 44100 samples) \* (1 min / 60 sec)  ~ 200 minutes of stereo audio.

You know, just in case.
